### PR TITLE
Add references to asset class examples

### DIFF
--- a/content/07_geometry/object-environment/environment-general.adoc
+++ b/content/07_geometry/object-environment/environment-general.adoc
@@ -11,3 +11,5 @@ An https://github.com/asam-ev/OpenMATERIAL-3D/tree/main/examples/environment_exa
 
 Groups with a local transform are indicated in the structure by a (T).
 This is only an indicator in the documentation and must not be contained in the actual node name.
+
+An example of an environment asset can be found in the examples folder of the https://github.com/asam-ev/OpenMATERIAL-3D/tree/main/examples/environment_example[GitHub repository].

--- a/content/07_geometry/object-human/human-general.adoc
+++ b/content/07_geometry/object-human/human-general.adoc
@@ -34,3 +34,5 @@ image::fig_human-structure.svg[,500]
 
 Bones with a local transform are indicated in the structure by a (T).
 This is only an indicator in the documentation and must not be contained in the actual node name.
+
+An example of a human asset can be found in the examples folder of the https://github.com/asam-ev/OpenMATERIAL-3D/tree/main/examples/human_example[GitHub repository].

--- a/content/07_geometry/object-vehicle/vehicle-general.adoc
+++ b/content/07_geometry/object-vehicle/vehicle-general.adoc
@@ -20,3 +20,5 @@ Additional group nodes may be added to support additional use cases, but they sh
 
 Groups with a local transform are indicated in the structure by a (T).
 This is only an indicator in the documentation and must not be contained in the actual node name.
+
+An example of a vehicle asset can be found in the examples folder of the https://github.com/asam-ev/OpenMATERIAL-3D/tree/main/examples/vehicle_example[GitHub repository].


### PR DESCRIPTION
## Describe your changes

- Added a reference to the examples for each asset class.
- I did not add references in the introductions as they are already referenced in the general [introduction for each file type](https://asam-ev.github.io/OpenMATERIAL-3D/asamopenmaterial/latest/specification/00_preface/introduction.html#_structure_and_file_formats).

## Issue ticket number and link

Fixes #491 

## Checklist before requesting a review

- [x] I have performed a self-review of my code/documentation.
- [x] My changes generate no new warnings during the documentation generation.