### PR TITLE
Set LightDefinitions half angle maximum to 180 degrees

### DIFF
--- a/schemas/asset_schema.json
+++ b/schemas/asset_schema.json
@@ -405,13 +405,13 @@
                     "innerConeAngle": {
                         "type": "number",
                         "minimum": 0,
-                        "maximum": 360,
+                        "maximum": 180,
                         "description": "The 1/2 opening angle in degree, measured from the center of the conical spotlight to the angle where the light falloff begins. If not set, the default is 0. This will be overwritten, if a photometric profile is set."
                     },
                     "outerConeAngle": {
                         "type": "number",
                         "minimum": 0,
-                        "maximum": 360,
+                        "maximum": 180,
                         "description": "The 1/2 opening angle in degree, measured from the center of the conical spotlight to the angle where the falloff ends. Set to 360° for point lights. If a photometric profile is set, this will be overwritten but serves as a fallback if a renderer cannot load the profile."
                     },
                     "luminousIntensity": {


### PR DESCRIPTION
## Describe your changes

Reduce LightDefinitions half angle maximum to 180 degrees

**Some questions to ask**:

- What is the change?
Reduce LightDefinitions half angle maximum from 360 degrees to 180 degrees
- What does it fix?
Non-physical half angle maximum value
- Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
Bug
- How has it been tested?
Schema validated

## Issue ticket number and link

closes #494 

## Mention a member

Add @mentions of the person or team responsible for reviewing the proposed changes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code/documentation.
- [x] My changes generate no new warnings during the documentation generation.